### PR TITLE
Support for customizable `PlexMediaItem` response types

### DIFF
--- a/Sources/PlexKit/Models/PlexMediaItem.swift
+++ b/Sources/PlexKit/Models/PlexMediaItem.swift
@@ -8,7 +8,19 @@
 
 import Foundation
 
-public struct PlexMediaItem: Codable, Hashable {
+public protocol PlexMediaItemType: Codable, Hashable {
+    var ratingKey: String { get }
+    var key: String { get }
+}
+
+/// The most basic media item type.
+/// Handy for performance-critical requests.
+public struct BasicPlexMediaItem: PlexMediaItemType {
+    public let ratingKey: String
+    public let key: String
+}
+
+public struct PlexMediaItem: PlexMediaItemType {
     public let ratingKey: String
     public let key: String
     public let parentRatingKey: String?

--- a/Sources/PlexKit/Requests/Resource/CollectionItems.swift
+++ b/Sources/PlexKit/Requests/Resource/CollectionItems.swift
@@ -10,14 +10,15 @@ import Foundation
 
 public extension Plex.Request {
     /// Requires Plex Media Server 1.22.3.4392.
-    struct CollectionItems: PlexResourceRequest {
+    typealias CollectionItems = _CollectionItems<PlexMediaItem>
+
+    struct _CollectionItems<MediaItem: PlexMediaItemType>: PlexResourceRequest {
         public var path: String { "library/collections/\(ratingKey)/children" }
         private let ratingKey: String
 
         public init(ratingKey: String) {
             self.ratingKey = ratingKey
         }
-
 
         public struct Response: Codable {
             public let mediaContainer: MediaContainer
@@ -29,14 +30,14 @@ public extension Plex.Request {
     }
 }
 
-public extension Plex.Request.CollectionItems {
+public extension Plex.Request._CollectionItems {
     struct MediaContainer: Codable {
         public let size: Int
         public let totalSize: Int?
         public let offset: Int?
-        private let Metadata: [PlexMediaItem]?
+        private let Metadata: [MediaItem]?
 
-        public var metadata: [PlexMediaItem] {
+        public var metadata: [MediaItem] {
             Metadata ?? []
         }
     }

--- a/Sources/PlexKit/Requests/Resource/ItemMetadata.swift
+++ b/Sources/PlexKit/Requests/Resource/ItemMetadata.swift
@@ -11,7 +11,9 @@ import Foundation
 public extension Plex.Request {
     /// Fetch metadata for a `PlexMediaItem`.
     /// - Warning: not tested.
-    struct ItemMetadata: PlexResourceRequest {
+    typealias ItemMetadata = _ItemMetadata<PlexMediaItem>
+
+    struct _ItemMetadata<MediaItem: PlexMediaItemType>: PlexResourceRequest {
         public var path: String { "library/metadata/\(ratingKey)" }
 
         public var queryItems: [URLQueryItem]? {
@@ -67,7 +69,7 @@ public extension Plex.Request {
     }
 }
 
-public extension Plex.Request.ItemMetadata.Response {
+public extension Plex.Request._ItemMetadata.Response {
     enum CodingKeys: String, CodingKey {
         case mediaContainer = "MediaContainer"
     }
@@ -83,9 +85,9 @@ public extension Plex.Request.ItemMetadata.Response {
         public let mediaTagPrefix: String?
         public let mediaTagVersion: Int?
 
-        private let Metadata: [PlexMediaItem]?
+        private let Metadata: [MediaItem]?
 
-        public var metadata: [PlexMediaItem] {
+        public var metadata: [MediaItem] {
             self.Metadata ?? []
         }
     }

--- a/Sources/PlexKit/Requests/Resource/LibraryItems.swift
+++ b/Sources/PlexKit/Requests/Resource/LibraryItems.swift
@@ -10,7 +10,9 @@ import Foundation
 
 public extension Plex.Request {
     /// Fetches a library's contents.
-    struct LibraryItems: PlexResourceRequest {
+    typealias LibraryItems = _LibraryItems<PlexMediaItem>
+
+    struct _LibraryItems<MediaItem: PlexMediaItemType>: PlexResourceRequest {
         public var path: String { "library/sections/\(key)/all" }
         public var queryItems: [URLQueryItem]? {
             var items: [URLQueryItem] = [
@@ -72,7 +74,7 @@ public extension Plex.Request {
     }
 }
 
-public extension Plex.Request.LibraryItems {
+public extension Plex.Request._LibraryItems {
     /// Filters the results of a `LibraryItems` request.
     enum Filter {
         /// Requests items in a specific set.
@@ -109,7 +111,7 @@ public extension Plex.Request.LibraryItems {
     }
 }
 
-public extension Plex.Request.LibraryItems.Response {
+public extension Plex.Request._LibraryItems.Response {
     enum CodingKeys: String, CodingKey {
         case mediaContainer = "MediaContainer"
     }
@@ -133,9 +135,9 @@ public extension Plex.Request.LibraryItems.Response {
         public let viewGroup: PlexMediaType?
         public let viewMode: Int?
 
-        private let Metadata: [PlexMediaItem]?
+        private let Metadata: [MediaItem]?
 
-        public var metadata: [PlexMediaItem] {
+        public var metadata: [MediaItem] {
             self.Metadata ?? []
         }
     }

--- a/Sources/PlexKit/Requests/Resource/PlaylistItems.swift
+++ b/Sources/PlexKit/Requests/Resource/PlaylistItems.swift
@@ -10,7 +10,9 @@ import Foundation
 
 public extension Plex.Request {
     /// Perform an action on a playlist's contents.
-    struct PlaylistItems: PlexResourceRequest {
+    typealias PlaylistItems = _PlaylistItems<PlexMediaItem>
+
+    struct _PlaylistItems<MediaItem: PlexMediaItemType>: PlexResourceRequest {
         public var path: String {
             let path = "playlists/\(ratingKey)/items"
             switch action {
@@ -73,6 +75,26 @@ public extension Plex.Request {
             }
         }
 
+        public struct MediaContainer: Codable {
+            public let size: Int
+            public let totalSize: Int?
+            public let allowSync: Bool?
+            public let composite: String?
+            public let duration: Int?
+            public let leafCount: Int?
+            public let offset: Int?
+            public let playlistType: PlexPlaylistType?
+            public let ratingKey: String?
+            public let smart: Bool?
+            public let title: String?
+
+            private let Metadata: [MediaItem]?
+
+            public var metadata: [MediaItem] {
+                self.Metadata ?? []
+            }
+        }
+
         public enum Action {
             /// Get the items in the playlist.
             case get
@@ -87,24 +109,3 @@ public extension Plex.Request {
     }
 }
 
-public extension Plex.Request.PlaylistItems {
-    struct MediaContainer: Codable {
-        public let size: Int
-        public let totalSize: Int?
-        public let allowSync: Bool?
-        public let composite: String?
-        public let duration: Int?
-        public let leafCount: Int?
-        public let offset: Int?
-        public let playlistType: PlexPlaylistType?
-        public let ratingKey: String?
-        public let smart: Bool?
-        public let title: String?
-
-        private let Metadata: [PlexMediaItem]?
-
-        public var metadata: [PlexMediaItem] {
-            self.Metadata ?? []
-        }
-    }
-}

--- a/Sources/PlexKit/Requests/Resource/RelatedMedia.swift
+++ b/Sources/PlexKit/Requests/Resource/RelatedMedia.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 public extension Plex.Request {
-    struct RelatedMedia: PlexResourceRequest {
+    typealias RelatedMedia = _RelatedMedia<PlexMediaItem>
+
+    struct _RelatedMedia<MediaItem: PlexMediaItemType>: PlexResourceRequest {
         public var path: String { "/hubs/metadata/\(ratingKey)/related" }
 
         /// - SeeAlso: `ratingKey` property of `MediaItem`.
@@ -30,7 +32,7 @@ public extension Plex.Request {
     }
 }
 
-public extension Plex.Request.RelatedMedia.Response {
+public extension Plex.Request._RelatedMedia.Response {
     enum CodingKeys: String, CodingKey {
         case mediaContainer = "MediaContainer"
     }
@@ -59,8 +61,8 @@ public extension Plex.Request.RelatedMedia.Response {
         public let context: String?
         public let more: Bool?
         public let style: String?
-        private let Metadata: [PlexMediaItem]?
-        public var metadata: [PlexMediaItem] {
+        private let Metadata: [MediaItem]?
+        public var metadata: [MediaItem] {
             self.Metadata ?? []
         }
     }

--- a/Tests/PlexKitTests/ResponsePerformanceTests.swift
+++ b/Tests/PlexKitTests/ResponsePerformanceTests.swift
@@ -1,0 +1,26 @@
+//
+//  ResponsePerformanceTests.swift
+//  PlexKitTests
+//
+//  Created by Lachlan Charlick on 28/2/22.
+//  Copyright © 2022 Lachlan Charlick. All rights reserved.
+//
+
+import XCTest
+import PlexKit
+
+class ResponsePerformanceTests: XCTestCase {
+    func testPlaylistItemsResponsePerformance() throws {
+        let data = try loadResource("playlist", ext: "json")
+        self.measure {
+            do {
+                for _ in 0...1_000 {
+                    let response = try Plex.Request._PlaylistItems<BasicPlexMediaItem>.response(from: data)
+                    XCTAssertEqual(response.mediaContainer.size, 10)
+                }
+            } catch {
+                XCTFail()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provide generic versions of requests that decode the large `PlexMediaItem` data structure. 
This gives clients an option to decode fewer properties for improved decode performance